### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ever2boost
 [![Build Status](https://travis-ci.org/BoostIO/ever2boost.svg?branch=master)](https://travis-ci.org/BoostIO/ever2boost)
 
-ever2bost is a CLI tool for conversion Evernote to Boostnote.
+ever2boost is a CLI tool for conversion Evernote to Boostnote.
 
 <div align='center'>
   <img width='70%' src="https://raw.githubusercontent.com/BoostIO/ever2boost/master/docs/images/img4.png">


### PR DESCRIPTION
Fix typo `ever2bost` to `ever2boost` at readme.