### PR TITLE
generate json pretty

### DIFF
--- a/lib/ever2boost/json_generator.rb
+++ b/lib/ever2boost/json_generator.rb
@@ -8,11 +8,11 @@ module Ever2boost
         folders = notebook_list.map do |list|
           {
             key: list.hash,
-            name: list.title,
-            color: list.color
+            color: list.color,
+            name: list.title
           }
         end
-        { folders: folders, version: '1.0' }.to_json
+        JSON.pretty_generate({ folders: folders, version: '1.0' })
       end
 
       def output(notebook_list, output_dir)

--- a/spec/json_generator_spec.rb
+++ b/spec/json_generator_spec.rb
@@ -5,7 +5,7 @@ describe Ever2boost::JsonGenerator do
   let (:notelist1) { Ever2boost::NoteList.new(title: 'title1', guid: '012345abcdef') }
   let (:notelist2) { Ever2boost::NoteList.new(title: 'title2', guid: '0123456abcde') }
   let (:notebook_list) { [notelist1, notelist2] }
-  let (:json) { '{"folders":[{"key":"012345abcdef","name":"title1","color":"#E10051"},{"key":"0123456abcde","name":"title2","color":"#E10051"}],"version":"1.0"}' }
+  let (:json) { "{\n  \"folders\": [\n    {\n      \"key\": \"012345abcdef\",\n      \"color\": \"#E10051\",\n      \"name\": \"title1\"\n    },\n    {\n      \"key\": \"0123456abcde\",\n      \"color\": \"#E10051\",\n      \"name\": \"title2\"\n    }\n  ],\n  \"version\": \"1.0\"\n}" }
   let (:output_dir) { 'spec/dist/evernote_storage' }
 
   describe '#build' do


### PR DESCRIPTION
Hello, thank you for creating nice app and import tool!
I fixed `json_generator.rb` to build `boostnote.json` as same as Boostnote itself by using `JSON.pretty_generate`, and replace the order of json keys.

before: 
```
{"folders":[{"key":"xxxx","name":"myFolderName","color":"#B013A4"},{"key":"yyyy","name":"myFolderName2","color":"#FF8E00"},(...)],"version":"1.0"}
```

after: 
```
{
  "folders": [
    {
      "key": "xxxx",
      "color": "#3FD941",
      "name": "myFolderName"
    },
    {
      "key": "yyyy",
      "color": "#2BA5F7",
      "name": "myFolderName2"
    },
    (...)
  ],
  "version": "1.0"
}
```
