### PR TITLE
Make xml version declaration optional regex

### DIFF
--- a/lib/ever2boost/enex_converter.rb
+++ b/lib/ever2boost/enex_converter.rb
@@ -29,11 +29,17 @@ module Ever2boost
             xml_document = REXML::Document.new(el.to_s).elements
             Note.new({
               title: xml_document['note/title'].text,
-              content: "<div>#{xml_document['note/content/text()'].to_s.sub(/<\?xml(.*?)\?>(.*?)<\!DOCTYPE(.*?)>/m, '')}</div>",
+              content: "<div>#{strip_doctype(xml_document)}</div>",
               output_dir: output_dir
             })
           end
         end.compact.flatten
+      end
+
+      private
+
+      def strip_doctype(xml_document)
+        xml_document['note/content/text()'].to_s.sub(/(<\?xml(.*?)\?>(.*?))?<\!DOCTYPE(.*?)>/m, '')
       end
     end
   end


### PR DESCRIPTION
This Fixes an issue where the doctype declaration is not stripped when the `?xml` version declaration is missing from the exported `.enex` file.  When the `DOCTYPE` declaration is left in, we get `REXML::ParseException: Declarations can only occur in the doctype declaration.`
raised exception as seen in [this issue](https://github.com/BoostIO/ever2boost/issues/14).

The regex pattern is modified to make the `<?xml>` part optional.