### PR TITLE
fixed exception

### DIFF
--- a/lib/ever2boost/evernote_authorizer.rb
+++ b/lib/ever2boost/evernote_authorizer.rb
@@ -2,6 +2,7 @@ require 'evernote-thrift'
 require 'ever2boost/note'
 require 'ever2boost/note_list'
 require 'ever2boost/util'
+require 'fileutils'
 
 module Ever2boost
   class EvernoteAuthorizer


### PR DESCRIPTION
Hey there, 
got an exception - fixed the import.

{$SOMEPATH}/gems/ever2boost-0.1.5/lib/ever2boost/evernote_authorizer.rb:58:in `import': uninitialized constant Ever2boost::EvernoteAuthorizer::FileUtils (NameError)
did you mean?  FileTest
	from /Users/manavortex/.gem/ruby/2.4.0/gems/ever2boost-0.1.5/lib/ever2boost/cli.rb:16:in `import'
	from {$SOMEPATH}/gems/2.4.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
	from {$SOMEPATH}/gems/2.4.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
	from {$SOMEPATH}/gems/2.4.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
	from {$SOMEPATH}/gems/2.4.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
	from /Users/manavortex/.gem/ruby/2.4.0/gems/ever2boost-0.1.5/exe/ever2boost:4:in `<top (required)>'
	from {$SOMEPATH}/gems/2.4.0/bin/ever2boost:23:in `load'
	from {$SOMEPATH}/gems/2.4.0/bin/ever2boost:23:in `<main>'
  ever2boost git:(master) ✗ subl /Users/manavortex/.gem/ruby/2.4.0/gems/ever2boost-0.1.5/lib/ever2boost/evernote_authorizer.rb